### PR TITLE
Added yotta config defined macro to disable LFCLK

### DIFF
--- a/cmsis-core-nrf51822/nrf51_bitfields.h
+++ b/cmsis-core-nrf51822/nrf51_bitfields.h
@@ -1047,8 +1047,6 @@
 /* Bits 1..0 : Clock source. */
 #define CLOCK_LFCLKSRC_SRC_Pos (0UL) /*!< Position of SRC field. */
 #define CLOCK_LFCLKSRC_SRC_Msk (0x3UL << CLOCK_LFCLKSRC_SRC_Pos) /*!< Bit mask of SRC field. */
-#define CLOCK_LFCLKSRC_SRC_RC (0UL) /*!< Internal 32KiHz RC oscillator. */
-#define CLOCK_LFCLKSRC_SRC_Xtal (1UL) /*!< External 32KiHz crystal. */
 #define CLOCK_LFCLKSRC_SRC_Synth (2UL) /*!< Internal 32KiHz synthesizer from HFCLK system clock. */
 
 /* Register: CLOCK_CTIV */

--- a/cmsis-core-nrf51822/nrf51_bitfields.h
+++ b/cmsis-core-nrf51822/nrf51_bitfields.h
@@ -1047,6 +1047,8 @@
 /* Bits 1..0 : Clock source. */
 #define CLOCK_LFCLKSRC_SRC_Pos (0UL) /*!< Position of SRC field. */
 #define CLOCK_LFCLKSRC_SRC_Msk (0x3UL << CLOCK_LFCLKSRC_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_LFCLKSRC_SRC_RC (0UL) /*!< Internal 32KiHz RC oscillator. */
+#define CLOCK_LFCLKSRC_SRC_Xtal (1UL) /*!< External 32KiHz crystal. */
 #define CLOCK_LFCLKSRC_SRC_Synth (2UL) /*!< Internal 32KiHz synthesizer from HFCLK system clock. */
 
 /* Register: CLOCK_CTIV */

--- a/source/system_nrf51.c
+++ b/source/system_nrf51.c
@@ -52,6 +52,10 @@ static bool is_disabled_in_debug_needed(void);
     uint32_t SystemCoreClock __attribute__((used)) = __SYSTEM_CLOCK;
 #endif
 
+#ifndef YOTTA_CFG_HARDWARE_CLOCKS_NRF_LFCLK_SRC
+#   define YOTTA_CFG_HARDWARE_CLOCKS_NRF_LFCLK_SRC 1UL /* The default is to wait for LFLCK to start */
+#endif
+
 void SystemCoreClockUpdate(void)
 {
     SystemCoreClock = __SYSTEM_CLOCK;
@@ -82,13 +86,7 @@ void SystemInit(void)
     }
 
     // Start the external 32khz crystal oscillator.
-
-    /* for Nordic devices without an external LF crystal */
-#if defined(TARGET_NRF_LFCLK_RC) || defined(YOTTA_CFG_HARDWARE_CLOCKS_NRF_LFCLK_RC)
-    NRF_CLOCK->LFCLKSRC             = (CLOCK_LFCLKSRC_SRC_RC << CLOCK_LFCLKSRC_SRC_Pos);
-#else
-    NRF_CLOCK->LFCLKSRC             = (CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos);
-#endif
+    NRF_CLOCK->LFCLKSRC             = (YOTTA_CFG_HARDWARE_CLOCKS_NRF_LFCLK_SRC << CLOCK_LFCLKSRC_SRC_Pos);
     NRF_CLOCK->EVENTS_LFCLKSTARTED  = 0;
     NRF_CLOCK->TASKS_LFCLKSTART     = 1;
 

--- a/source/system_nrf51.c
+++ b/source/system_nrf51.c
@@ -83,7 +83,8 @@ void SystemInit(void)
 
     // Start the external 32khz crystal oscillator.
 
-#if defined(TARGET_DELTA_DFCM_NNN40) || defined(TARGET_HRM1017)
+    /* for Nordic devices without an external LF crystal */
+#if defined(TARGET_NRF_LFCLK_RC) || defined(YOTTA_CFG_HARDWARE_CLOCKS_NRF_LFCLK_RC)
     NRF_CLOCK->LFCLKSRC             = (CLOCK_LFCLKSRC_SRC_RC << CLOCK_LFCLKSRC_SRC_Pos);
 #else
     NRF_CLOCK->LFCLKSRC             = (CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos);


### PR DESCRIPTION
This macro is required to be defined by targets that do not have a LFCLK,
otherwise they get stucked in an endless loop checking whether LFCLK started.