### PR TITLE
Update nrf51-sdk dependency to ^2.0.0

### DIFF
--- a/module.json
+++ b/module.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/ARMmbed/cmsis-core-nrf51822",
   "license": "Apache-2",
   "dependencies": {
-    "nrf51-sdk": "^1.0.0"
+    "nrf51-sdk": "^2.0.0"
   },
   "extraIncludes": [
     "cmsis-core-nrf51822"


### PR DESCRIPTION
This is because the major version of the nrf51-sdk module was updated to 2.0.0 when it was upgraded to SDK 10.0.0.
@pan- @LiyouZhou @0xc0170